### PR TITLE
Font weight customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Create a new barcode.  Returns a canvas element.
   font: 'monospace',
   textAlign: 'center',
   fontSize: 12,
+  fontWeight: 'bold',
   backgroundColor: '',
   lineColor: "#000",
   customLabel:null, // Will be displayed if displayValue is set to true

--- a/modules/index.js
+++ b/modules/index.js
@@ -11,6 +11,7 @@ const defaults = {
 	font: 'monospace',
 	textAlign: 'center',
 	fontSize: 12,
+	fontWeight: 'normal',
 	backgroundColor: '',
 	lineColor: '#000'
 }
@@ -21,7 +22,7 @@ function _drawBarcodeText (text, canvas, opts) {
 
 	y = opts.height
 
-	ctx.font = `${opts.fontSize}px ${opts.font}`
+	ctx.font = `${opts.fontWeight} ${opts.fontSize}px ${opts.font}`
 	ctx.textBaseline = 'bottom'
 	ctx.textBaseline = 'top'
 


### PR DESCRIPTION
Added option to override the barcode label's font weight.
P.S.: I've tried to build the library before commiting, but I'm getting webpack errors.
